### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
 name = "divan"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf174e1957cfadab3bcb040afb210ea8b7c2ffc094eb88b750be61fc601835e"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
  "cfg-if",
  "clap",
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-divan = "0.1.8"
+divan = "0.1.11"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 veil = { path = "../veil" }

--- a/benchmarks/benches/benchmarks.rs
+++ b/benchmarks/benches/benchmarks.rs
@@ -14,23 +14,23 @@ use veil::{Digest, PrivateKey};
 const KB: u64 = 1024;
 const LENS: &[u64] = &[0, KB, 8 * KB, 32 * KB, 64 * KB, 128 * KB, KB * KB];
 
-#[divan::bench(consts = LENS)]
-fn encrypt<const LEN: u64>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn encrypt(bencher: divan::Bencher, len: u64) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
             let pk_a = PrivateKey::random(&mut rng);
             let pk_b = PrivateKey::random(&mut rng);
-            (rng, pk_a, pk_b, io::repeat(0).take(LEN), io::sink())
+            (rng, pk_a, pk_b, io::repeat(0).take(len), io::sink())
         })
-        .counter(BytesCount::new(LEN))
+        .counter(BytesCount::new(len))
         .bench_values(|(rng, pk_a, pk_b, plaintext, ciphertext)| {
             pk_a.encrypt(rng, plaintext, ciphertext, &[pk_b.public_key()], None, None).unwrap()
         });
 }
 
-#[divan::bench(consts = LENS)]
-fn decrypt<const LEN: u64>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn decrypt(bencher: divan::Bencher, len: u64) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
@@ -39,7 +39,7 @@ fn decrypt<const LEN: u64>(bencher: divan::Bencher) {
             let mut ciphertext = Cursor::new(Vec::new());
             pk_a.encrypt(
                 &mut rng,
-                io::repeat(0).take(LEN),
+                io::repeat(0).take(len),
                 &mut ciphertext,
                 &[pk_b.public_key()],
                 None,
@@ -48,69 +48,69 @@ fn decrypt<const LEN: u64>(bencher: divan::Bencher) {
             .unwrap();
             (pk_a, pk_b, Cursor::new(ciphertext.into_inner()))
         })
-        .counter(BytesCount::new(LEN))
+        .counter(BytesCount::new(len))
         .bench_refs(|(pk_a, pk_b, ciphertext)| {
             pk_b.decrypt(ciphertext, io::sink(), &pk_a.public_key()).unwrap()
         });
 }
 
-#[divan::bench(consts = LENS)]
-fn sign<const LEN: u64>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn sign(bencher: divan::Bencher, len: u64) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
             let pk = PrivateKey::random(&mut rng);
-            (rng, pk, io::repeat(0).take(LEN))
+            (rng, pk, io::repeat(0).take(len))
         })
-        .counter(BytesCount::new(LEN))
+        .counter(BytesCount::new(len))
         .bench_refs(|(rng, pk, message)| pk.sign(rng, message).unwrap());
 }
 
-#[divan::bench(consts = LENS)]
-fn verify<const LEN: u64>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn verify(bencher: divan::Bencher, len: u64) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
             let pk = PrivateKey::random(&mut rng);
-            let sig = pk.sign(rng, io::repeat(0).take(LEN)).unwrap();
-            (pk, io::repeat(0).take(LEN), sig)
+            let sig = pk.sign(rng, io::repeat(0).take(len)).unwrap();
+            (pk, io::repeat(0).take(len), sig)
         })
-        .counter(BytesCount::new(LEN))
+        .counter(BytesCount::new(len))
         .bench_refs(|(pk, message, sig)| pk.public_key().verify(message, sig));
 }
 
-#[divan::bench(consts = LENS)]
-fn digest<const LEN: u64>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn digest(bencher: divan::Bencher, len: u64) {
     bencher
-        .with_inputs(|| io::repeat(0).take(LEN))
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| io::repeat(0).take(len))
+        .counter(BytesCount::new(len))
         .bench_values(|message| Digest::new(&[""; 0], message).unwrap());
 }
 
 const TIME_COSTS: &[u8] = &[1, 2, 4, 6, 8];
 
-#[divan::bench(consts = TIME_COSTS)]
-fn pbenc_time<const TIME: u8>(bencher: divan::Bencher) {
+#[divan::bench(args = TIME_COSTS)]
+fn pbenc_time(bencher: divan::Bencher, time: u8) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
             let pk = PrivateKey::random(&mut rng);
             (rng, pk)
         })
-        .bench_values(|(rng, pk)| pk.store(io::sink(), rng, b"passphrase", TIME, 0));
+        .bench_values(|(rng, pk)| pk.store(io::sink(), rng, b"passphrase", time, 0));
 }
 
 const MEMORY_COSTS: &[u8] = &[1, 2, 4, 6, 8];
 
-#[divan::bench(consts = MEMORY_COSTS)]
-fn pbenc_memory<const MEMORY: u8>(bencher: divan::Bencher) {
+#[divan::bench(args = MEMORY_COSTS)]
+fn pbenc_memory(bencher: divan::Bencher, memory: u8) {
     bencher
         .with_inputs(|| {
             let mut rng = ChaChaRng::seed_from_u64(0xDEADBEEF);
             let pk = PrivateKey::random(&mut rng);
             (rng, pk)
         })
-        .bench_values(|(rng, pk)| pk.store(io::sink(), rng, b"passphrase", 0, MEMORY));
+        .bench_values(|(rng, pk)| pk.store(io::sink(), rng, b"passphrase", 0, memory));
 }
 
 #[global_allocator]


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.